### PR TITLE
Implement dialog to adjust scan parameters. Add notifications about scan status

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -9,34 +9,124 @@
  */
 
 var ScannerMenuPlugin = {
-  attach: function (menu) {
-    var fileList = menu.fileList;
+	attach: function (menu) {
+		var plugin = this;
+		var fileList = menu.fileList;
 
-    menu.addMenuEntry({
-      id: 'scanner',
-      displayName: 'Scan Image',
-      templateName: 'scan.jpg',
-      iconClass: 'icon-filetype-scanner',
-      fileType: 'file',
-      actionHandler: function(name) {
+		menu.addMenuEntry({
+			id: 'scanner',
+			displayName: 'Scan Image',
+			templateName: 'scan.jpg',
+			iconClass: 'icon-filetype-scanner',
+			fileType: 'file',
+			actionHandler: function (name) {
+				plugin.scanOptionsModal('Please adjust scan parameters', 'Scan Options', function (result, formData) {
+					if (!result) {
+						OC.Notification.showTemporary('Scan aborted.');
+						return;
+					}
+					var dir = fileList.getCurrentDirectory();
+					OC.Notification.showTemporary('Scan started.');
+					$.ajax({
+						url: OC.generateUrl('/apps/scanner/scan'),
+						async: true,
+						type: 'POST',
+						data: {
+							filename: name,
+							dir: dir,
+							scanOptions: formData
+						},
+						success: function (data) {
+							fileList.changeDirectory(dir, true, true);
+							OC.Notification.showTemporary('Scan complete');
+						},
+						error: function (data) {
+							OC.Notification.showTemporary(data.result);
+						}
+					});
+				});
 
-        var dir = fileList.getCurrentDirectory();
-        // TODO: Should this be ajax?
-        // TODO: Scans are slow, show a spinner / bar
-        $.ajax({
-          url: OC.generateUrl('/apps/scanner/scan'),
-          async: false,
-          type: 'POST',
-          data: {
-            filename: name,
-            dir: dir
-          },
-          success: function(data) {
-            console.log(data);
-          }
-        });
-      }
-    });
-  }
+			}
+		});
+	},
+
+	getTemplate: function (tplFile) {
+		var defer = $.Deferred();
+		var self = this;
+		$.get(OC.filePath('scanner', 'templates', tplFile), function (tmpl) {
+			self.$messageTemplate = $(tmpl);
+			defer.resolve(self.$messageTemplate);
+		})
+			.fail(function (jqXHR, textStatus, errorThrown) {
+				defer.reject(jqXHR.status, errorThrown);
+			});
+		return defer.promise();
+	},
+
+	scanOptionsModal: function (text, title, callback, modal) {
+		var plugin = this;
+		return $.when(this.getTemplate('optionsdialog.html')).then(function ($tmpl) {
+			var dialogName = 'oc-dialog-' + OCdialogs.dialogsCounter + '-content';
+			var dialogId = '#' + dialogName;
+			var $dlg = $tmpl.octemplate({
+				dialog_name: dialogName,
+				title: title,
+				message: text,
+				type: 'notice'
+			});
+			if (modal === undefined) {
+				modal = false;
+			}
+			$('body').append($dlg);
+
+			// wrap callback in _.once():
+			// only call callback once and not twice (button handler and close
+			// event) but call it for the close event, if ESC or the x is hit
+			if (callback !== undefined) {
+				callback = _.once(callback);
+			}
+
+			var buttonlist = [{
+				text: t('core', 'No'),
+				click: function () {
+					if (callback !== undefined) {
+						callback(false, plugin.formArrayToObject($('form', $dlg).serializeArray()));
+					}
+					$(dialogId).ocdialog('close');
+				}
+			}, {
+				text: t('core', 'Yes'),
+				click: function () {
+					if (callback !== undefined) {
+						callback(true, plugin.formArrayToObject($('form', $dlg).serializeArray()));
+					}
+					$(dialogId).ocdialog('close');
+				},
+				defaultButton: true
+			}
+			];
+
+			$(dialogId).ocdialog({
+				closeOnEscape: true,
+				modal: modal,
+				buttons: buttonlist,
+				close: function () {
+					// callback is already fired if Yes/No is clicked directly
+					if (callback !== undefined) {
+						callback(false, plugin.formArrayToObject($('form', $dlg).serializeArray()));
+					}
+				}
+			});
+			OCdialogs.dialogsCounter++;
+		});
+	},
+	formArrayToObject: function (formArray) {
+
+		var returnArray = {};
+		for (var i = 0; i < formArray.length; i++) {
+			returnArray[formArray[i]['name']] = formArray[i]['value'];
+		}
+		return returnArray;
+	}
 };
 OC.Plugins.register('OCA.Files.NewFileMenu', ScannerMenuPlugin);

--- a/lib/Storage/ScannerStorage.php
+++ b/lib/Storage/ScannerStorage.php
@@ -12,29 +12,53 @@
 namespace OCA\Scanner\Storage;
 
 use Exception;
+use OC\Files\Node\Folder;
+use OCP\Files\GenericFileException;
+use OCP\Files\NotPermittedException;
 
-class StorageException extends Exception {}
+class StorageException extends Exception {
+}
 
 class ScannerStorage {
 
-  private $storage;
+	private $storage;
+	private $modes = [
+		0 => 'Color',
+		1 => 'Gray',
+		2 => 'Lineart'
+	];
 
-  public function __construct($storage){
-    $this->storage = $storage;
-  }
+	public function __construct(Folder $storage) {
+		$this->storage = $storage;
+	}
 
-  public function scanFile($name) {
-    if($this->storage->nodeExists($name)) {
-      // TODO: This can happen because we don't refresh the file listing
-      throw new StorageException('File already exists');
-    } else {
-      $file = $this->storage->newFile($name);
-      // TODO: There's probably a way to stream this without the tempfile
-      exec("scanimage --mode Gray --resolution 150 | pnmtojpeg > /tmp/img");
-      $data = file_get_contents('/tmp/img');
-      $file->putContent($data);
-      return 'success';
-    }
-  }
+	/**
+	 * @param $name
+	 * @param string $mode
+	 * @param int $resolution
+	 * @return string
+	 * @throws GenericFileException
+	 * @throws NotPermittedException
+	 * @throws StorageException
+	 */
+	public function scanFile($name, $mode = 0, $resolution = 300) {
+		if ($this->storage->nodeExists($name)) {
+			// TODO: This can happen because we don't refresh the file listing
+			throw new StorageException('File already exists');
+		}
+		$file = $this->storage->newFile($name);
+		// TODO: There's probably a way to stream this without the tempfile
+		exec(
+			"scanimage --mode {$this->modes[$mode]} --resolution {$resolution} | pnmtojpeg > /tmp/img",
+			$output,
+			$status
+		);
+		if ($status) {
+			throw new StorageException('Something went wrong while attempting to scan');
+		}
+		$data = file_get_contents('/tmp/img');
+		$file->putContent($data);
+		return 'success';
+	}
 
 }

--- a/templates/optionsdialog.html
+++ b/templates/optionsdialog.html
@@ -1,0 +1,16 @@
+<div id="{dialog_name}" title="{title}">
+	<p>{message}</p>
+	<form>
+		<label>
+			Resolution
+			<input name="resolution" type="number" value="300"></label>
+		<label>
+			Mode
+			<select name="mode">
+				<option value="0" selected>Color</option>
+				<option value="1">Greyscale</option>
+				<option value="2">Lineart</option>
+			</select>
+		</label>
+	</form>
+</div>


### PR DESCRIPTION
This PR fixes #1 by doing the following:

- Makes the ajax call to trigger the scan async
- Refreshes the file list on success
- Adds basic notifications about scan status
- After a filename was chosen, a config modal pops up before the actual post request is sent
- In this dialog, you are able to set scan resolution and mode (Color|Gray|Lineart) which will later get passed into `scanimage`
- Adds some more error/exception handling on the backend side
- Some refactoring here and there (->better type hints for IDE support in particular)


It should be trivial to extend the dialog with more options if we need them.