### PR TITLE
Fix PHP "undefined" errors

### DIFF
--- a/controller/scannercontroller.php
+++ b/controller/scannercontroller.php
@@ -49,6 +49,8 @@ class ScannerController extends Controller {
 	 * @return DataResponse
 	 */
 	public function scan($filename, $dir, $scanOptions) {
+		$status = Http::STATUS_OK; 
+		$result = 'result';
 		$path = $dir . '/' . $filename;
 		$mode = (int)$scanOptions['mode'];
 		$resolution = (int)$scanOptions['resolution'];


### PR DESCRIPTION
Fix undefined variables and index errors in PHP reported in https://github.com/e-alfred/nextcloud-scanner/issues/15.